### PR TITLE
fix: generate in `strict` mode

### DIFF
--- a/common/soql-grammar.js
+++ b/common/soql-grammar.js
@@ -16,7 +16,7 @@ module.exports = function defineGrammar(dialect) {
       subquery: ($) => seq("(", $.soql_query_body, ")"),
 
       soql_query_body: ($) => {
-        s = [
+        const s = [
           field("select_clause", $.select_clause),
           field("from_clause", $.from_clause),
           optional(


### PR DESCRIPTION
The grammar will fail to evaluate if JS is run in 'strict mode', since the variable assignment is assigned as a global, which is disallowed in strict mode.