### PR TITLE
Correctly parse line comments on Windows/CRLF line endings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,4 @@ tree-sitter-language = "0.1"
 cc = "1.1"
 
 [dev-dependencies]
-tree-sitter = "0.24"
+tree-sitter = "0.25.10"

--- a/apex/grammar.js
+++ b/apex/grammar.js
@@ -919,7 +919,7 @@ module.exports = grammar({
     // http://stackoverflow.com/questions/13014947/regex-to-match-a-c-style-multiline-comment/36328890#36328890
     comment: ($) => choice($.line_comment, $.block_comment),
 
-    line_comment: ($) => token(prec(PREC.COMMENT, seq("//", /[^\n]*/))),
+    line_comment: ($) => token(prec(PREC.COMMENT, seq("//", /[^\r\n]*/))),
 
     block_comment: ($) =>
       token(prec(PREC.COMMENT, seq("/*", /[^*]*\*+([^/*][^*]*\*+)*/, "/"))),

--- a/apex/src/grammar.json
+++ b/apex/src/grammar.json
@@ -5816,7 +5816,7 @@
             },
             {
               "type": "PATTERN",
-              "value": "[^\\n]*"
+              "value": "[^\\r\\n]*"
             }
           ]
         }
@@ -10529,5 +10529,6 @@
     "_simple_type",
     "_unannotated_type",
     "comment"
-  ]
+  ],
+  "reserved": {}
 }

--- a/apex/src/node-types.json
+++ b/apex/src/node-types.json
@@ -5421,7 +5421,8 @@
   },
   {
     "type": "block_comment",
-    "named": true
+    "named": true,
+    "extra": true
   },
   {
     "type": "boolean_type",
@@ -5545,7 +5546,8 @@
   },
   {
     "type": "line_comment",
-    "named": true
+    "named": true,
+    "extra": true
   },
   {
     "type": "maxDescriptorPerRecord",

--- a/apex/src/tree_sitter/parser.h
+++ b/apex/src/tree_sitter/parser.h
@@ -18,6 +18,11 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
+typedef struct TSLanguageMetadata {
+  uint8_t major_version;
+  uint8_t minor_version;
+  uint8_t patch_version;
+} TSLanguageMetadata;
 #endif
 
 typedef struct {
@@ -26,10 +31,11 @@ typedef struct {
   bool inherited;
 } TSFieldMapEntry;
 
+// Used to index the field and supertype maps.
 typedef struct {
   uint16_t index;
   uint16_t length;
-} TSFieldMapSlice;
+} TSMapSlice;
 
 typedef struct {
   bool visible;
@@ -79,6 +85,12 @@ typedef struct {
   uint16_t external_lex_state;
 } TSLexMode;
 
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+  uint16_t reserved_word_set_id;
+} TSLexerMode;
+
 typedef union {
   TSParseAction action;
   struct {
@@ -93,7 +105,7 @@ typedef struct {
 } TSCharacterRange;
 
 struct TSLanguage {
-  uint32_t version;
+  uint32_t abi_version;
   uint32_t symbol_count;
   uint32_t alias_count;
   uint32_t token_count;
@@ -109,13 +121,13 @@ struct TSLanguage {
   const TSParseActionEntry *parse_actions;
   const char * const *symbol_names;
   const char * const *field_names;
-  const TSFieldMapSlice *field_map_slices;
+  const TSMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   const TSSymbol *alias_sequences;
-  const TSLexMode *lex_modes;
+  const TSLexerMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
   TSSymbol keyword_capture_token;
@@ -129,15 +141,23 @@ struct TSLanguage {
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
   const TSStateId *primary_state_ids;
+  const char *name;
+  const TSSymbol *reserved_words;
+  uint16_t max_reserved_word_set_size;
+  uint32_t supertype_count;
+  const TSSymbol *supertype_symbols;
+  const TSMapSlice *supertype_map_slices;
+  const TSSymbol *supertype_map_entries;
+  TSLanguageMetadata metadata;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
   uint32_t index = 0;
   uint32_t size = len - index;
   while (size > 1) {
     uint32_t half_size = size / 2;
     uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
+    const TSCharacterRange *range = &ranges[mid_index];
     if (lookahead >= range->start && lookahead <= range->end) {
       return true;
     } else if (lookahead > range->end) {
@@ -145,7 +165,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }
     size -= half_size;
   }
-  TSCharacterRange *range = &ranges[index];
+  const TSCharacterRange *range = &ranges[index];
   return (lookahead >= range->start && lookahead <= range->end);
 }
 


### PR DESCRIPTION
`line_comment` was incorrectly including the `\r` character on file using CRLF (Windows).

This change updates the regex in the `line_comment` rule to explicitly exclude `\r` along with `\n`, changing the match pattern from `/[^\n]*/` to `/[^\r\n]*/`.

I was not able to add a test in corpus. I tried to use the `:cst` attribute with no avail so I could assert node length.

---

Given the following file (with CRLF):
```apex
// test comment

```

Here the previous parse value:

```
0:0  - 1:0    parser_output
0:0  - 0:16     line_comment `// test comment\r`
```

Now with the fix:

```
0:0  - 1:0    parser_output
0:0  - 0:15     line_comment `// test comment`
```

_Command used for the output_: `tree-sitter.exe parse --cst .\test.crlf.cls`

