### PR TITLE
Include LICENSE in crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ autoexamples = false
 
 build = "bindings/rust/build.rs"
 include = [
+  "LICENSE",
   "common",
   "bindings/rust",
   "apex/grammar.js",


### PR DESCRIPTION
This is needed by the MIT license and required when packaging in distributions like Fedora