### PR TITLE
fix: wrap multi_line_string_literal in token() to prevent // being parsed as line comments

### DIFF
--- a/apex/grammar.js
+++ b/apex/grammar.js
@@ -988,6 +988,6 @@ module.exports = grammar({
     string_literal: ($) => /'(\\[nNrRtTbBfFuU"'_%\\]|[^\\'])*'/,
 
     multi_line_string_literal: ($) =>
-      seq("'''", repeat(/[^']''?[^']|\\'|[^']/), "'''"),
+      token(seq("'''", repeat(/[^']''?[^']|\\'|[^']/), "'''")),
   },
 });

--- a/apex/test/corpus/variables.txt
+++ b/apex/test/corpus/variables.txt
@@ -536,3 +536,24 @@ String str = '''
       (identifier)
       (assignment_operator)
       (multi_line_string_literal))))
+
+================================================================================
+VARIABLE Multi-Line With URLs
+================================================================================
+
+String str = '''
+    {
+        "SuccessURL":"http://www.success.nl",
+        "FailureURL":"http://www.fail.nl"
+    }
+''';
+
+--------------------------------------------------------------------------------
+
+(parser_output
+  (local_variable_declaration
+    (type_identifier)
+    (variable_declarator
+      (identifier)
+      (assignment_operator)
+      (multi_line_string_literal))))


### PR DESCRIPTION
## Problem

`multi_line_string_literal` is defined with `seq()` (a non-terminal), so tree-sitter applies all grammar rules — including `line_comment` — inside the triple-quoted string content.

This means any `//` inside a multiline string is lexed as a comment, corrupting the content. The most common real-world case is URLs:

```apex
String body = '''
    {
        "SuccessURL": "http://www.example.com",
        "FailureURL": "http://www.example.com/fail"
    }
''';
```

Gets parsed as if `//www.example.com` is a line comment, producing garbage output in any formatter or analysis tool built on this grammar.

## Fix

Wrap the rule in `token()`, making the entire triple-quoted span a single terminal token — consistent with how `string_literal` is already defined:

```js
// Before
multi_line_string_literal: ($) =>
  seq("'''", repeat(/[^']''?[^']|\\'|[^']/), "'''"),

// After
multi_line_string_literal: ($) =>
  token(seq("'''", repeat(/[^']''?[^']|\\'|[^']/), "'''")),
```

A corpus test for the URL case is included.

## Notes

`parser.c` is not included in this PR — please regenerate with `npm run build-apex` before merging. The existing diff between the published `parser.c` and a fresh generation is already very large due to CLI version drift, so including it here would make the PR unreadable.